### PR TITLE
feat: add docker and cloud foundry deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY sap_abbreviation_dictionary.json ./
+
+RUN npm run build && npm prune --omit=dev
+
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV TRANSPORT=http
+ENV PORT=3001
+
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/sap_abbreviation_dictionary.json ./sap_abbreviation_dictionary.json
+
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ Then add to your MCP client config:
 }
 ```
 
+### Option 4 — Docker
+
+Build and run the server as a container with the HTTP transport enabled:
+
+```bash
+docker build -t sap-released-objects-server .
+docker run --rm -p 3001:3001 sap-released-objects-server
+```
+
+The container exposes:
+
+- MCP endpoint: `http://localhost:3001/mcp`
+- REST API: `http://localhost:3001/api`
+- Health check: `http://localhost:3001/health`
+
 ## Features
 
 - **Search SAP objects** — classes, CDS views, tables, data elements, BDEFs, etc.
@@ -261,3 +276,13 @@ git push origin main --tags
 ```
 
 GitHub Actions will then build on 3 runners (Ubuntu, Windows, macOS)
+
+## Deploying To SAP BTP Cloud Foundry
+
+This repository includes a `manifest.yml` for Cloud Foundry deployments on SAP BTP.
+
+```bash
+cf push
+```
+
+The manifest uses the Node.js buildpack, installs dependencies, builds the TypeScript project during staging, and starts the app in HTTP mode so BTP can route traffic to `/mcp`, `/api`, and `/health`.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,12 @@
+---
+applications:
+  - name: sap-released-objects-server
+    memory: 256M
+    disk_quota: 512M
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    command: npm run build && TRANSPORT=http npm start
+    env:
+      NODE_ENV: production
+      NPM_CONFIG_PRODUCTION: "false"


### PR DESCRIPTION
Body:
## Summary
- add a `Dockerfile` for containerized HTTP deployments
- add a `manifest.yml` for SAP BTP Cloud Foundry deployment
- document Docker and Cloud Foundry usage in `README.md`

## Changes
- added a multi-stage Docker build based on Node 20 Alpine
- configured the container to run the app in HTTP mode on port `3001`
- added a Cloud Foundry manifest using the Node.js buildpack
- configured Cloud Foundry startup to build the TypeScript project and start the server with `TRANSPORT=http`
- documented local Docker usage and SAP BTP Cloud Foundry deployment steps

## Verification
- `npm run build`
- `npm test` currently fails due to an existing repository test failure in `src/services/search.test.ts:392`
- `cf --version`

## Notes
- Docker image build was not verified in this environment because the `docker` CLI is not installed
- branch pushed to fork: `cadiraca:feat/docker-and-cf-deploy`
- target base branch: `main`
Suggested base/compare:
- Base repository: ClementRingot/sap-released-objects-server
- Base branch: main
- Head repository: cadiraca/sap-released-objects-server
- Compare branch: feat/docker-and-cf-deploy